### PR TITLE
feat: add login, logout, refresh, and me endpoints (#6)

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -2,6 +2,12 @@ from django.contrib.auth.models import User
 from rest_framework import serializers
 
 
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'first_name', 'last_name']
+
+
 class RegisterSerializer(serializers.Serializer):
     username = serializers.CharField(max_length=150)
     email = serializers.EmailField()

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,7 +1,12 @@
 from django.urls import path
+from rest_framework_simplejwt.views import TokenRefreshView
 
 from . import views
 
 urlpatterns = [
     path('auth/register/', views.register_view, name='register'),
+    path('auth/login/', views.login_view, name='login'),
+    path('auth/logout/', views.logout_view, name='logout'),
+    path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('auth/me/', views.MeAPIView.as_view(), name='me'),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,10 +1,13 @@
+from django.contrib.auth import authenticate
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 
-from .serializers import RegisterSerializer
+from .serializers import RegisterSerializer, UserSerializer
 
 
 @api_view(['POST'])
@@ -19,3 +22,59 @@ def register_view(request):
             'refresh': str(refresh),
         }, status=status.HTTP_201_CREATED)
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def login_view(request):
+    username = request.data.get('username')
+    password = request.data.get('password')
+
+    if not username or not password:
+        return Response(
+            {'detail': 'Username and password are required.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    user = authenticate(username=username, password=password)
+    if user is None:
+        return Response(
+            {'detail': 'Invalid credentials.'},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    refresh = RefreshToken.for_user(user)
+    return Response({
+        'access': str(refresh.access_token),
+        'refresh': str(refresh),
+    }, status=status.HTTP_200_OK)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def logout_view(request):
+    refresh_token = request.data.get('refresh')
+    if not refresh_token:
+        return Response(
+            {'detail': 'Refresh token is required.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        token = RefreshToken(refresh_token)
+        token.blacklist()
+    except TokenError:
+        return Response(
+            {'detail': 'Invalid or expired token.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return Response({'detail': 'Successfully logged out.'}, status=status.HTTP_200_OK)
+
+
+class MeAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = UserSerializer(request.user)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
     'corsheaders',
     'api',
 ]


### PR DESCRIPTION
## Issue
Closes #6

## Changes
- `backend/backend/settings.py` — Added `rest_framework_simplejwt.token_blacklist` to INSTALLED_APPS for refresh token blacklisting
- `backend/api/serializers.py` — Added `UserSerializer` (ModelSerializer) for returning user data on `/api/auth/me/`
- `backend/api/views.py` — Added `login_view` (FBV), `logout_view` (FBV), and `MeAPIView` (CBV)
- `backend/api/urls.py` — Registered `/api/auth/login/`, `/api/auth/logout/`, `/api/auth/refresh/`, `/api/auth/me/`

## How to test
1. Start the server: `cd backend && source venv/bin/activate && python manage.py migrate && python manage.py runserver`
2. Register a user:
   ```
   curl -X POST http://127.0.0.1:8000/api/auth/register/ -H "Content-Type: application/json" -d '{"username":"testuser","email":"test@test.com","password":"testpass123","password_confirm":"testpass123"}'
   ```
3. Login (expect 200 with access+refresh tokens):
   ```
   curl -X POST http://127.0.0.1:8000/api/auth/login/ -H "Content-Type: application/json" -d '{"username":"testuser","password":"testpass123"}'
   ```
4. Login with wrong password (expect 401):
   ```
   curl -X POST http://127.0.0.1:8000/api/auth/login/ -H "Content-Type: application/json" -d '{"username":"testuser","password":"wrong"}'
   ```
5. Get current user (expect 200 with user data):
   ```
   curl http://127.0.0.1:8000/api/auth/me/ -H "Authorization: Bearer <access_token>"
   ```
6. Refresh token (expect 200 with new access token):
   ```
   curl -X POST http://127.0.0.1:8000/api/auth/refresh/ -H "Content-Type: application/json" -d '{"refresh":"<refresh_token>"}'
   ```
7. Logout (expect 200, refresh token blacklisted):
   ```
   curl -X POST http://127.0.0.1:8000/api/auth/logout/ -H "Authorization: Bearer <access_token>" -H "Content-Type: application/json" -d '{"refresh":"<refresh_token>"}'
   ```
8. Try using the blacklisted refresh token again (expect 401)