### PR TITLE
feat: add health check endpoint and frontend connectivity test (#4)

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('auth/logout/', views.logout_view, name='logout'),
     path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('auth/me/', views.MeAPIView.as_view(), name='me'),
+    path('health/', views.health_check, name='health_check'),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -78,3 +78,9 @@ class MeAPIView(APIView):
     def get(self, request):
         serializer = UserSerializer(request.user)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def health_check(request):
+    return Response({'status': 'ok'}, status=status.HTTP_200_OK)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -630,6 +630,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -890,31 +891,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -5393,6 +5369,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -6,6 +7,7 @@ import { routes } from './app.routes';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
-  ]
+    provideHttpClient(),
+    provideRouter(routes),
+  ],
 };

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,3 +1,14 @@
+<div style="padding: 1rem; font-family: sans-serif;">
+  <h3>Backend Health Check</h3>
+  @if (healthStatus()) {
+    <p style="color: green;">Backend status: {{ healthStatus() }}</p>
+  } @else if (healthError()) {
+    <p style="color: red;">Backend error: {{ healthError() }}</p>
+  } @else {
+    <p>Checking backend connection...</p>
+  }
+</div>
+
 <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
 <!-- * * * * * * * * * * * The content below * * * * * * * * * * * -->
 <!-- * * * * * * * * * * is only a placeholder * * * * * * * * * * -->

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,12 +1,25 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+
+import { HealthService } from './core/services/health.service';
 
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet],
   templateUrl: './app.html',
-  styleUrl: './app.css'
+  styleUrl: './app.css',
 })
-export class App {
+export class App implements OnInit {
   protected readonly title = signal('frontend');
+  protected readonly healthStatus = signal<string | null>(null);
+  protected readonly healthError = signal<string | null>(null);
+
+  private healthService = inject(HealthService);
+
+  ngOnInit(): void {
+    this.healthService.checkHealth().subscribe({
+      next: (res) => this.healthStatus.set(res.status),
+      error: (err) => this.healthError.set(err.message),
+    });
+  }
 }

--- a/frontend/src/app/core/services/health.service.ts
+++ b/frontend/src/app/core/services/health.service.ts
@@ -1,0 +1,16 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+interface HealthResponse {
+  status: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class HealthService {
+  private http = inject(HttpClient);
+
+  checkHealth(): Observable<HealthResponse> {
+    return this.http.get<HealthResponse>('http://127.0.0.1:8000/api/health/');
+  }
+}


### PR DESCRIPTION
## Issue
Closes #4

## Changes
- `backend/api/views.py` — Added `health_check` FBV returning `{"status": "ok"}`
- `backend/api/urls.py` — Registered `GET /api/health/` route
- `frontend/src/app/app.config.ts` — Added `provideHttpClient()` to application providers
- `frontend/src/app/core/services/health.service.ts` — Created `HealthService` with `checkHealth()` method
- `frontend/src/app/app.ts` — Injected `HealthService`, calls health endpoint on init, stores result in signals
- `frontend/src/app/app.html` — Added health check status display at the top of the page

## How to test
1. Start the backend:
   ```bash
   cd backend && source venv/bin/activate && python manage.py migrate && python manage.py runserver
   ```
2. Verify the endpoint directly:
   ```bash
   curl http://127.0.0.1:8000/api/health/
   # Expected: {"status":"ok"}
   ```
3. Start the frontend:
   ```bash
   cd frontend && npm start
   ```
4. Open `http://localhost:4200` in a browser
5. You should see **"Backend status: ok"** in green at the top of the page
6. Stop the backend and refresh — you should see a red error message, confirming error handling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)