### PR TITLE
feat: add login and register pages (#7)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+import { LoginComponent } from './pages/login/login';
+import { RegisterComponent } from './pages/register/register';
+
+export const routes: Routes = [
+  { path: 'login', component: LoginComponent },
+  { path: 'register', component: RegisterComponent },
+];

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -1,0 +1,47 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+
+import { AuthTokens, LoginRequest, RegisterRequest, User } from '../../models/auth.model';
+
+const API_URL = 'http://127.0.0.1:8000/api/auth';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+
+  login(data: LoginRequest): Observable<AuthTokens> {
+    return this.http.post<AuthTokens>(`${API_URL}/login/`, data).pipe(
+      tap((tokens) => this.storeTokens(tokens)),
+    );
+  }
+
+  register(data: RegisterRequest): Observable<AuthTokens> {
+    return this.http.post<AuthTokens>(`${API_URL}/register/`, data);
+  }
+
+  logout(): Observable<{ detail: string }> {
+    const refresh = localStorage.getItem('refresh_token');
+    return this.http
+      .post<{ detail: string }>(`${API_URL}/logout/`, { refresh })
+      .pipe(tap(() => this.clearTokens()));
+  }
+
+  getAccessToken(): string | null {
+    return localStorage.getItem('access_token');
+  }
+
+  isLoggedIn(): boolean {
+    return !!this.getAccessToken();
+  }
+
+  private storeTokens(tokens: AuthTokens): void {
+    localStorage.setItem('access_token', tokens.access);
+    localStorage.setItem('refresh_token', tokens.refresh);
+  }
+
+  private clearTokens(): void {
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('refresh_token');
+  }
+}

--- a/frontend/src/app/models/auth.model.ts
+++ b/frontend/src/app/models/auth.model.ts
@@ -1,0 +1,24 @@
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  username: string;
+  email: string;
+  password: string;
+  password_confirm: string;
+}
+
+export interface AuthTokens {
+  access: string;
+  refresh: string;
+}
+
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+}

--- a/frontend/src/app/pages/login/login.html
+++ b/frontend/src/app/pages/login/login.html
@@ -1,0 +1,23 @@
+<div class="auth-container">
+  <h2>Войти</h2>
+
+  @if (errorMessage) {
+    <div class="error-message">{{ errorMessage }}</div>
+  }
+
+  <form (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="username">Username</label>
+      <input id="username" type="text" [(ngModel)]="username" name="username" required />
+    </div>
+
+    <div class="form-group">
+      <label for="password">Password</label>
+      <input id="password" type="password" [(ngModel)]="password" name="password" required />
+    </div>
+
+    <button type="submit">Войти</button>
+  </form>
+
+  <p>Нет аккаунта? <a routerLink="/register">Зарегистрироваться</a></p>
+</div>

--- a/frontend/src/app/pages/login/login.ts
+++ b/frontend/src/app/pages/login/login.ts
@@ -1,0 +1,39 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+
+import { AuthService } from '../../core/services/auth.service';
+import { LoginRequest } from '../../models/auth.model';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [FormsModule, RouterLink],
+  templateUrl: './login.html',
+})
+export class LoginComponent {
+  private authService = inject(AuthService);
+  private router = inject(Router);
+
+  username = '';
+  password = '';
+  errorMessage = '';
+
+  onSubmit(): void {
+    this.errorMessage = '';
+
+    const data: LoginRequest = {
+      username: this.username,
+      password: this.password,
+    };
+
+    this.authService.login(data).subscribe({
+      next: () => {
+        this.router.navigate(['/items']);
+      },
+      error: (err) => {
+        this.errorMessage = err.error?.detail || 'Login failed. Please try again.';
+      },
+    });
+  }
+}

--- a/frontend/src/app/pages/register/register.html
+++ b/frontend/src/app/pages/register/register.html
@@ -1,0 +1,39 @@
+<div class="auth-container">
+  <h2>Регистрация</h2>
+
+  @if (errorMessage) {
+    <div class="error-message">{{ errorMessage }}</div>
+  }
+
+  <form (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="username">Username</label>
+      <input id="username" type="text" [(ngModel)]="username" name="username" required />
+    </div>
+
+    <div class="form-group">
+      <label for="email">Email</label>
+      <input id="email" type="email" [(ngModel)]="email" name="email" required />
+    </div>
+
+    <div class="form-group">
+      <label for="password">Password</label>
+      <input id="password" type="password" [(ngModel)]="password" name="password" required />
+    </div>
+
+    <div class="form-group">
+      <label for="passwordConfirm">Confirm Password</label>
+      <input
+        id="passwordConfirm"
+        type="password"
+        [(ngModel)]="passwordConfirm"
+        name="passwordConfirm"
+        required
+      />
+    </div>
+
+    <button type="submit">Зарегистрироваться</button>
+  </form>
+
+  <p>Уже есть аккаунт? <a routerLink="/login">Войти</a></p>
+</div>

--- a/frontend/src/app/pages/register/register.ts
+++ b/frontend/src/app/pages/register/register.ts
@@ -1,0 +1,56 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+
+import { AuthService } from '../../core/services/auth.service';
+import { RegisterRequest } from '../../models/auth.model';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [FormsModule, RouterLink],
+  templateUrl: './register.html',
+})
+export class RegisterComponent {
+  private authService = inject(AuthService);
+  private router = inject(Router);
+
+  username = '';
+  email = '';
+  password = '';
+  passwordConfirm = '';
+  errorMessage = '';
+
+  onSubmit(): void {
+    this.errorMessage = '';
+
+    const data: RegisterRequest = {
+      username: this.username,
+      email: this.email,
+      password: this.password,
+      password_confirm: this.passwordConfirm,
+    };
+
+    this.authService.register(data).subscribe({
+      next: () => {
+        this.router.navigate(['/login']);
+      },
+      error: (err) => {
+        if (err.error && typeof err.error === 'object') {
+          const messages: string[] = [];
+          for (const key of Object.keys(err.error)) {
+            const value = err.error[key];
+            if (Array.isArray(value)) {
+              messages.push(...value);
+            } else {
+              messages.push(String(value));
+            }
+          }
+          this.errorMessage = messages.join(' ');
+        } else {
+          this.errorMessage = 'Registration failed. Please try again.';
+        }
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Issue
Closes #7

## Changes
- `frontend/src/app/models/auth.model.ts` — Added `LoginRequest`, `RegisterRequest`, `AuthTokens`, `User` interfaces
- `frontend/src/app/core/services/auth.service.ts` — Created `AuthService` with login, register, logout, and token storage
- `frontend/src/app/pages/login/login.ts` + `login.html` — Login page with username/password form, error handling, redirect to `/items`
- `frontend/src/app/pages/register/register.ts` + `register.html` — Register page with username/email/password/confirm form, validation errors, redirect to `/login`
- `frontend/src/app/app.routes.ts` — Added `/login` and `/register` routes

Re-applies the feature from PR #33 (which was reverted in PR #34) with the template fix already on main via PR #35.

## How to test
1. Start backend: `cd backend && source venv/bin/activate && python manage.py runserver`
2. Start frontend: `cd frontend && npm start`
3. Open `http://localhost:4200/register` — form should be visible, fill in fields, submit
4. Open `http://localhost:4200/login` — enter credentials, submit
5. Test error cases: duplicate username on register, wrong password on login
6. Verify navigation links between login and register pages