### PR TITLE
feat: add auth service methods, HTTP interceptor, and auth guard (#8)

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,5 +1,7 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+
+import { authInterceptor } from './core/interceptors/auth.interceptor';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -7,7 +9,7 @@ import { routes } from './app.routes';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([authInterceptor])),
     provideRouter(routes),
   ],
 };

--- a/frontend/src/app/core/guards/auth.guard.ts
+++ b/frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isLoggedIn()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login']);
+};

--- a/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,18 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { AuthService } from '../services/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const token = authService.getAccessToken();
+
+  if (token) {
+    const cloned = req.clone({
+      setHeaders: { Authorization: `Bearer ${token}` },
+    });
+    return next(cloned);
+  }
+
+  return next(req);
+};

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -31,6 +31,17 @@ export class AuthService {
     return localStorage.getItem('access_token');
   }
 
+  refreshToken(): Observable<AuthTokens> {
+    const refresh = localStorage.getItem('refresh_token');
+    return this.http.post<AuthTokens>(`${API_URL}/refresh/`, { refresh }).pipe(
+      tap((tokens) => this.storeTokens(tokens)),
+    );
+  }
+
+  getMe(): Observable<User> {
+    return this.http.get<User>(`${API_URL}/me/`);
+  }
+
   isLoggedIn(): boolean {
     return !!this.getAccessToken();
   }


### PR DESCRIPTION
## Issue
Closes #8

## Changes
- **frontend/src/app/core/services/auth.service.ts** — Added `refreshToken()` (POST `/api/auth/refresh/`) and `getMe()` (GET `/api/auth/me/`) methods
- **frontend/src/app/core/interceptors/auth.interceptor.ts** — Created functional HTTP interceptor that attaches `Authorization: Bearer <token>` header to outgoing requests
- **frontend/src/app/core/guards/auth.guard.ts** — Created functional route guard (`CanActivateFn`) that redirects unauthenticated users to `/login`
- **frontend/src/app/app.config.ts** — Registered the auth interceptor via `withInterceptors([authInterceptor])`

Note: Interfaces (`User`, `LoginRequest`, `RegisterRequest`, `AuthTokens`) already existed in `frontend/src/app/models/auth.model.ts` from #7.

## How to test
1. Start backend: `cd backend && source venv/bin/activate && python manage.py runserver`
2. Start frontend: `cd frontend && npm start`
3. **Interceptor**: Log in via `/login`, open DevTools → Network tab, call any API — verify `Authorization: Bearer ...` header is present on requests
4. **Guard**: Add `canActivate: [authGuard]` to a route in `app.routes.ts`, navigate to it without logging in — should redirect to `/login`
5. **refreshToken()**: After login, call `authService.refreshToken()` — should return new tokens and update localStorage
6. **getMe()**: After login, call `authService.getMe()` — should return the current user object