### PR TITLE
feat: add serializers and API for Category and Item (#11)

### DIFF
--- a/backend/api/permissions.py
+++ b/backend/api/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class IsOwnerOrReadOnly(BasePermission):
+    """
+    Allow read-only access for any request.
+    Write permissions are only allowed to the owner of the object.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+        return obj.owner == request.user

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,11 +1,29 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
+from .models import Category, Item
+
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['id', 'username', 'email', 'first_name', 'last_name']
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = '__all__'
+
+
+class ItemSerializer(serializers.ModelSerializer):
+    category_name = serializers.CharField(source='category.name', read_only=True)
+    owner_username = serializers.CharField(source='owner.username', read_only=True)
+
+    class Meta:
+        model = Item
+        fields = '__all__'
+        read_only_fields = ['owner']
 
 
 class RegisterSerializer(serializers.Serializer):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -10,4 +10,8 @@ urlpatterns = [
     path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('auth/me/', views.MeAPIView.as_view(), name='me'),
     path('health/', views.health_check, name='health_check'),
+    path('categories/', views.CategoryListAPIView.as_view(), name='category-list'),
+    path('items/', views.ItemListCreateAPIView.as_view(), name='item-list-create'),
+    path('items/<int:pk>/', views.ItemDetailAPIView.as_view(), name='item-detail'),
+    path('items/me/', views.MyItemsListAPIView.as_view(), name='my-items'),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import authenticate
+from django.db.models import Q
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -7,7 +8,14 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 
-from .serializers import RegisterSerializer, UserSerializer
+from .models import Category, Item
+from .permissions import IsOwnerOrReadOnly
+from .serializers import (
+    CategorySerializer,
+    ItemSerializer,
+    RegisterSerializer,
+    UserSerializer,
+)
 
 
 @api_view(['POST'])
@@ -84,3 +92,112 @@ class MeAPIView(APIView):
 @permission_classes([AllowAny])
 def health_check(request):
     return Response({'status': 'ok'}, status=status.HTTP_200_OK)
+
+
+class CategoryListAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        categories = Category.objects.all()
+        serializer = CategorySerializer(categories, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ItemListCreateAPIView(APIView):
+    def get_permissions(self):
+        if self.request.method == 'POST':
+            return [IsAuthenticated()]
+        return [AllowAny()]
+
+    def get(self, request):
+        queryset = Item.objects.select_related('category', 'owner').all()
+
+        item_type = request.query_params.get('item_type')
+        if item_type:
+            queryset = queryset.filter(item_type=item_type)
+
+        category = request.query_params.get('category')
+        if category:
+            queryset = queryset.filter(category_id=category)
+
+        item_status = request.query_params.get('status')
+        if item_status:
+            queryset = queryset.filter(status=item_status)
+
+        search = request.query_params.get('search')
+        if search:
+            queryset = queryset.filter(
+                Q(title__icontains=search) | Q(description__icontains=search)
+            )
+
+        serializer = ItemSerializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        serializer = ItemSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(owner=request.user)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class ItemDetailAPIView(APIView):
+    permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
+
+    def get_object(self, pk):
+        try:
+            item = Item.objects.select_related('category', 'owner').get(pk=pk)
+        except Item.DoesNotExist:
+            return None
+        self.check_object_permissions(self.request, item)
+        return item
+
+    def get(self, request, pk):
+        item = self.get_object(pk)
+        if item is None:
+            return Response(
+                {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
+            )
+        serializer = ItemSerializer(item)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def put(self, request, pk):
+        item = self.get_object(pk)
+        if item is None:
+            return Response(
+                {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
+            )
+        serializer = ItemSerializer(item, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def patch(self, request, pk):
+        item = self.get_object(pk)
+        if item is None:
+            return Response(
+                {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
+            )
+        serializer = ItemSerializer(item, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request, pk):
+        item = self.get_object(pk)
+        if item is None:
+            return Response(
+                {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
+            )
+        item.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MyItemsListAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        items = Item.objects.select_related('category', 'owner').filter(
+            owner=request.user
+        )
+        serializer = ItemSerializer(items, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Issue
Closes #11

## Changes
- `backend/api/permissions.py` — created `IsOwnerOrReadOnly` custom permission (safe methods for all, write methods for owner only)
- `backend/api/serializers.py` — added `CategorySerializer` (ModelSerializer, all fields) and `ItemSerializer` (ModelSerializer, all fields + nested `category_name`, `owner_username`; `owner` read-only)
- `backend/api/views.py` — added 4 CBVs: `CategoryListAPIView` (GET), `ItemListCreateAPIView` (GET with filters + POST), `ItemDetailAPIView` (GET/PUT/PATCH/DELETE), `MyItemsListAPIView` (GET current user's items)
- `backend/api/urls.py` — registered routes: `categories/`, `items/`, `items/<int:pk>/`, `items/me/`

## How to test
1. Start the backend: `cd backend && python manage.py runserver`
2. Create a category via Django shell: `python manage.py shell -c "from api.models import Category; Category.objects.create(name='Electronics')"`
3. Register a user: `curl -X POST http://127.0.0.1:8000/api/auth/register/ -H 'Content-Type: application/json' -d '{"username":"testuser","email":"test@test.com","password":"TestPass123!","password_confirm":"TestPass123!"}'`
4. Use the returned access token for authenticated requests below (replace `$TOKEN`)
5. `GET /api/categories/` — returns list of categories
6. `POST /api/items/` — create an item (requires auth): `curl -X POST http://127.0.0.1:8000/api/items/ -H 'Content-Type: application/json' -H 'Authorization: Bearer $TOKEN' -d '{"title":"Lost Phone","description":"Black iPhone","item_type":"lost","location":"Library","date_lost_or_found":"2026-04-15","category":1}'`
7. `GET /api/items/` — list all items (public)
8. `GET /api/items/?item_type=lost&search=phone` — filtered list
9. `GET /api/items/1/` — item detail (requires auth)
10. `PATCH /api/items/1/` — partial update (owner only)
11. `DELETE /api/items/1/` — delete (owner only)
12. `GET /api/items/me/` — current user's items (requires auth)