### PR TITLE
feat: add ItemDetailComponent with image upload (#13)

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -130,11 +130,11 @@ class ItemListCreateAPIView(APIView):
                 Q(title__icontains=search) | Q(description__icontains=search)
             )
 
-        serializer = ItemSerializer(queryset, many=True)
+        serializer = ItemSerializer(queryset, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def post(self, request):
-        serializer = ItemSerializer(data=request.data)
+        serializer = ItemSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         serializer.save(owner=request.user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -157,7 +157,7 @@ class ItemDetailAPIView(APIView):
             return Response(
                 {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
             )
-        serializer = ItemSerializer(item)
+        serializer = ItemSerializer(item, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def put(self, request, pk):
@@ -166,7 +166,7 @@ class ItemDetailAPIView(APIView):
             return Response(
                 {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
             )
-        serializer = ItemSerializer(item, data=request.data)
+        serializer = ItemSerializer(item, data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -177,7 +177,7 @@ class ItemDetailAPIView(APIView):
             return Response(
                 {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
             )
-        serializer = ItemSerializer(item, data=request.data, partial=True)
+        serializer = ItemSerializer(item, data=request.data, partial=True, context={'request': request})
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -199,5 +199,5 @@ class MyItemsListAPIView(APIView):
         items = Item.objects.select_related('category', 'owner').filter(
             owner=request.user
         )
-        serializer = ItemSerializer(items, many=True)
+        serializer = ItemSerializer(items, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 
 import { LoginComponent } from './pages/login/login';
 import { ItemsComponent } from './pages/items/items';
+import { ItemDetailComponent } from './pages/item-detail/item-detail';
 import { ItemFormComponent } from './pages/item-form/item-form';
 import { authGuard } from './core/guards/auth.guard';
 
@@ -9,6 +10,7 @@ export const routes: Routes = [
   { path: 'login', component: LoginComponent, data: { mode: 'login' } },
   { path: 'register', component: LoginComponent, data: { mode: 'register' } },
   { path: 'items', component: ItemsComponent, canActivate: [authGuard] },
+  { path: 'items/:id', component: ItemDetailComponent, canActivate: [authGuard] },
   { path: 'create-item', component: ItemFormComponent, canActivate: [authGuard] },
   { path: 'edit-item/:id', component: ItemFormComponent, canActivate: [authGuard] },
   { path: '', pathMatch: 'full', redirectTo: 'items' },

--- a/frontend/src/app/core/services/item.service.ts
+++ b/frontend/src/app/core/services/item.service.ts
@@ -26,6 +26,10 @@ export class ItemService {
     return this.http.put<Item>(`${API_URL}/items/${id}/`, this.toFormData(data));
   }
 
+  deleteItem(id: number): Observable<void> {
+    return this.http.delete<void>(`${API_URL}/items/${id}/`);
+  }
+
   private toFormData(data: ItemCreateRequest): FormData {
     const fd = new FormData();
     fd.append('title', data.title);

--- a/frontend/src/app/pages/item-detail/item-detail.html
+++ b/frontend/src/app/pages/item-detail/item-detail.html
@@ -1,0 +1,135 @@
+<div style="max-width: 720px; margin: 40px auto; padding: 0 16px;">
+  <a routerLink="/items" style="display: inline-block; margin-bottom: 16px;">&larr; Back to items</a>
+
+  @if (loading()) {
+    <p>Loading...</p>
+  }
+
+  @if (errorMessage(); as err) {
+    <p style="color: #b00020;">{{ err }}</p>
+  }
+
+  @if (item(); as i) {
+    <div style="border: 1px solid #ddd; border-radius: 8px; padding: 24px;">
+      <div style="display: flex; justify-content: space-between; align-items: start; flex-wrap: wrap; gap: 8px;">
+        <h2 style="margin: 0;">{{ i.title }}</h2>
+        <div style="display: flex; gap: 8px;">
+          <span
+            style="
+              padding: 4px 10px;
+              border-radius: 12px;
+              font-size: 0.85em;
+              font-weight: 500;
+              color: #fff;
+            "
+            [style.background-color]="
+              i.item_type === 'lost' ? '#d32f2f' : '#388e3c'
+            "
+          >
+            {{ i.item_type === 'lost' ? 'Lost' : 'Found' }}
+          </span>
+          <span
+            style="
+              padding: 4px 10px;
+              border-radius: 12px;
+              font-size: 0.85em;
+              font-weight: 500;
+              color: #fff;
+            "
+            [style.background-color]="
+              i.status === 'active'
+                ? '#1976d2'
+                : i.status === 'claimed'
+                  ? '#f57c00'
+                  : '#388e3c'
+            "
+          >
+            {{ i.status | titlecase }}
+          </span>
+        </div>
+      </div>
+
+      @if (i.image) {
+        <img
+          [src]="i.image"
+          [alt]="i.title"
+          style="
+            width: 100%;
+            max-height: 400px;
+            object-fit: cover;
+            border-radius: 8px;
+            margin-top: 16px;
+          "
+        />
+      }
+
+      <p style="margin-top: 16px; line-height: 1.6;">{{ i.description }}</p>
+
+      <div
+        style="
+          display: grid;
+          grid-template-columns: auto 1fr;
+          gap: 8px 16px;
+          margin-top: 16px;
+          font-size: 0.95em;
+        "
+      >
+        <strong>Category:</strong>
+        <span>{{ i.category_name }}</span>
+
+        <strong>Location:</strong>
+        <span>{{ i.location }}</span>
+
+        <strong>Date:</strong>
+        <span>{{ i.date_lost_or_found | date: 'longDate' }}</span>
+
+        <strong>Posted by:</strong>
+        <span>{{ i.owner_username }}</span>
+
+        <strong>Created:</strong>
+        <span>{{ i.created_at | date: 'medium' }}</span>
+      </div>
+
+      @if (isOwner()) {
+        <div
+          style="
+            display: flex;
+            gap: 12px;
+            margin-top: 24px;
+            padding-top: 16px;
+            border-top: 1px solid #eee;
+          "
+        >
+          <a
+            [routerLink]="['/edit-item', i.id]"
+            style="
+              padding: 8px 20px;
+              background: #1976d2;
+              color: #fff;
+              text-decoration: none;
+              border-radius: 4px;
+              font-size: 0.95em;
+            "
+          >
+            Edit
+          </a>
+          <button
+            type="button"
+            (click)="onDelete()"
+            style="
+              padding: 8px 20px;
+              background: #d32f2f;
+              color: #fff;
+              border: none;
+              border-radius: 4px;
+              cursor: pointer;
+              font-size: 0.95em;
+            "
+          >
+            Delete
+          </button>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/item-detail/item-detail.ts
+++ b/frontend/src/app/pages/item-detail/item-detail.ts
@@ -1,0 +1,65 @@
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { DatePipe, TitleCasePipe } from '@angular/common';
+
+import { ItemService } from '../../core/services/item.service';
+import { AuthService } from '../../core/services/auth.service';
+import { Item } from '../../models/item.model';
+import { User } from '../../models/auth.model';
+
+@Component({
+  selector: 'app-item-detail',
+  standalone: true,
+  imports: [RouterLink, DatePipe, TitleCasePipe],
+  templateUrl: './item-detail.html',
+})
+export class ItemDetailComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private itemService = inject(ItemService);
+  private authService = inject(AuthService);
+
+  protected readonly item = signal<Item | null>(null);
+  protected readonly me = signal<User | null>(null);
+  protected readonly errorMessage = signal('');
+  protected readonly loading = signal(true);
+
+  protected readonly isOwner = computed(
+    () => this.item() !== null && this.me() !== null && this.item()!.owner === this.me()!.id,
+  );
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+
+    this.itemService.getItem(id).subscribe({
+      next: (item) => {
+        this.item.set(item);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.errorMessage.set('Failed to load item.');
+        this.loading.set(false);
+      },
+    });
+
+    this.authService.getMe().subscribe({
+      next: (me) => {
+        this.me.set(me);
+      },
+    });
+  }
+
+  onDelete(): void {
+    const item = this.item();
+    if (!item || !confirm('Are you sure you want to delete this item?')) {
+      return;
+    }
+
+    this.itemService.deleteItem(item.id).subscribe({
+      next: () => this.router.navigate(['/items']),
+      error: () => {
+        this.errorMessage.set('Failed to delete item.');
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Issue
Closes #13

## Changes
- `frontend/src/app/pages/item-detail/item-detail.ts` — new standalone component using Angular signals; loads item and current user, computed `isOwner` for conditional rendering, delete with confirmation dialog
- `frontend/src/app/pages/item-detail/item-detail.html` — template displaying all item fields (title, description, type, status, location, date, category, author), type/status badges, image, conditional Edit/Delete buttons for owner
- `frontend/src/app/core/services/item.service.ts` — added `deleteItem(id)` method
- `frontend/src/app/app.routes.ts` — added `items/:id` route with `authGuard`
- `backend/api/views.py` — added `context={'request': request}` to all `ItemSerializer` calls so image fields return absolute URLs

## How to test
1. Start backend: `cd backend && python manage.py runserver`
2. Start frontend: `cd frontend && npm start`
3. Log in at `http://localhost:4200/login`
4. Navigate to `http://localhost:4200/items/1` (use an existing item ID)
5. Verify all fields display correctly: title, description, type badge (red=lost/green=found), status badge (blue=active/orange=claimed/green=resolved), image, location, date, category, author
6. **As item owner:** Edit and Delete buttons should appear. Click Delete → confirm dialog → redirects to `/items`. Click Edit → navigates to `/edit-item/:id`
7. **As non-owner:** Edit and Delete buttons should not appear