### PR TITLE
feat: add Item and Category services with mark-resolved endpoint (#15)

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path('items/', views.ItemListCreateAPIView.as_view(), name='item-list-create'),
     path('items/<int:pk>/', views.ItemDetailAPIView.as_view(), name='item-detail'),
     path('items/me/', views.MyItemsListAPIView.as_view(), name='my-items'),
+    path('items/<int:pk>/mark-resolved/', views.mark_resolved_view, name='item-mark-resolved'),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -201,3 +201,25 @@ class MyItemsListAPIView(APIView):
         )
         serializer = ItemSerializer(items, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def mark_resolved_view(request, pk):
+    try:
+        item = Item.objects.get(pk=pk)
+    except Item.DoesNotExist:
+        return Response(
+            {'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND
+        )
+
+    if item.owner != request.user:
+        return Response(
+            {'detail': 'You do not have permission to perform this action.'},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    item.status = Item.Status.RESOLVED
+    item.save(update_fields=['status', 'updated_at'])
+    serializer = ItemSerializer(item, context={'request': request})
+    return Response(serializer.data, status=status.HTTP_200_OK)

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 
 import { LoginComponent } from './pages/login/login';
 import { ItemsComponent } from './pages/items/items';
+import { MyItemsComponent } from './pages/my-items/my-items';
 import { ItemDetailComponent } from './pages/item-detail/item-detail';
 import { ItemFormComponent } from './pages/item-form/item-form';
 import { authGuard } from './core/guards/auth.guard';
@@ -10,6 +11,7 @@ export const routes: Routes = [
   { path: 'login', component: LoginComponent, data: { mode: 'login' } },
   { path: 'register', component: LoginComponent, data: { mode: 'register' } },
   { path: 'items', component: ItemsComponent, canActivate: [authGuard] },
+  { path: 'items/me', component: MyItemsComponent, canActivate: [authGuard] },
   { path: 'items/:id', component: ItemDetailComponent, canActivate: [authGuard] },
   { path: 'create-item', component: ItemFormComponent, canActivate: [authGuard] },
   { path: 'edit-item/:id', component: ItemFormComponent, canActivate: [authGuard] },

--- a/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,18 +1,26 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
 
 import { AuthService } from '../services/auth.service';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
+  const router = inject(Router);
   const token = authService.getAccessToken();
 
-  if (token) {
-    const cloned = req.clone({
-      setHeaders: { Authorization: `Bearer ${token}` },
-    });
-    return next(cloned);
-  }
+  const request = token
+    ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+    : req;
 
-  return next(req);
+  return next(request).pipe(
+    catchError((error) => {
+      if (error.status === 401 && authService.isLoggedIn()) {
+        authService.clearTokens();
+        router.navigateByUrl('/login');
+      }
+      return throwError(() => error);
+    }),
+  );
 };

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -51,7 +51,7 @@ export class AuthService {
     localStorage.setItem('refresh_token', tokens.refresh);
   }
 
-  private clearTokens(): void {
+  clearTokens(): void {
     localStorage.removeItem('access_token');
     localStorage.removeItem('refresh_token');
   }

--- a/frontend/src/app/core/services/item.service.ts
+++ b/frontend/src/app/core/services/item.service.ts
@@ -41,8 +41,16 @@ export class ItemService {
     return this.http.put<Item>(`${API_URL}/items/${id}/`, this.toFormData(data));
   }
 
+  getMyItems(): Observable<Item[]> {
+    return this.http.get<Item[]>(`${API_URL}/items/me/`);
+  }
+
   deleteItem(id: number): Observable<void> {
     return this.http.delete<void>(`${API_URL}/items/${id}/`);
+  }
+
+  markResolved(id: number): Observable<Item> {
+    return this.http.post<Item>(`${API_URL}/items/${id}/mark-resolved/`, {});
   }
 
   private toFormData(data: ItemCreateRequest): FormData {

--- a/frontend/src/app/pages/item-detail/item-detail.ts
+++ b/frontend/src/app/pages/item-detail/item-detail.ts
@@ -31,6 +31,11 @@ export class ItemDetailComponent implements OnInit {
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'));
 
+    if (isNaN(id)) {
+      this.router.navigate(['/items']);
+      return;
+    }
+
     this.itemService.getItem(id).subscribe({
       next: (item) => {
         this.item.set(item);

--- a/frontend/src/app/pages/items/items.html
+++ b/frontend/src/app/pages/items/items.html
@@ -117,11 +117,16 @@
   }
 
   .items-page__filters select {
-    padding: 8px 12px;
+    padding: 8px 28px 8px 12px;
     border: 1px solid #ccc;
     border-radius: 6px;
     font-size: 14px;
     background: #fff;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23666'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    cursor: pointer;
   }
 
   .items-page__create-btn {

--- a/frontend/src/app/pages/my-items/my-items.html
+++ b/frontend/src/app/pages/my-items/my-items.html
@@ -1,0 +1,67 @@
+<div class="my-items">
+  <header class="my-items__header">
+    <a routerLink="/items" class="my-items__back">&larr; Back to items</a>
+    <h1>My Items</h1>
+  </header>
+
+  @if (errorMessage()) {
+    <p class="my-items__error">{{ errorMessage() }}</p>
+  }
+
+  @if (loading()) {
+    <p class="my-items__status">Loading your items…</p>
+  } @else if (items().length === 0 && !errorMessage()) {
+    <p class="my-items__status">You haven't posted any items yet.</p>
+  } @else {
+    <div class="my-items__grid">
+      @for (item of items(); track item.id) {
+        <app-item-card [item]="item" />
+      }
+    </div>
+  }
+</div>
+
+<style>
+  .my-items {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 24px 16px;
+  }
+
+  .my-items__header {
+    margin-bottom: 24px;
+  }
+
+  .my-items__back {
+    font-size: 14px;
+    color: #1565c0;
+    text-decoration: none;
+  }
+
+  .my-items__back:hover {
+    text-decoration: underline;
+  }
+
+  .my-items__header h1 {
+    margin: 8px 0 0;
+    font-size: 24px;
+  }
+
+  .my-items__error {
+    color: #b00020;
+    margin-bottom: 16px;
+  }
+
+  .my-items__status {
+    text-align: center;
+    color: #666;
+    padding: 40px 0;
+    font-size: 16px;
+  }
+
+  .my-items__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+  }
+</style>

--- a/frontend/src/app/pages/my-items/my-items.ts
+++ b/frontend/src/app/pages/my-items/my-items.ts
@@ -1,0 +1,40 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { ItemService } from '../../core/services/item.service';
+import { Item } from '../../models/item.model';
+import { ItemCardComponent } from '../../shared/item-card/item-card';
+
+@Component({
+  selector: 'app-my-items',
+  standalone: true,
+  imports: [RouterLink, ItemCardComponent],
+  templateUrl: './my-items.html',
+})
+export class MyItemsComponent implements OnInit {
+  private itemService = inject(ItemService);
+
+  items = signal<Item[]>([]);
+  loading = signal(false);
+  errorMessage = signal('');
+
+  ngOnInit(): void {
+    this.loadItems();
+  }
+
+  loadItems(): void {
+    this.loading.set(true);
+    this.errorMessage.set('');
+
+    this.itemService.getMyItems().subscribe({
+      next: (items) => {
+        this.items.set(items);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.errorMessage.set(err?.error?.detail || 'Failed to load your items.');
+        this.loading.set(false);
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Issue
Closes #15

## Changes
- `backend/api/views.py` — added `mark_resolved_view` FBV (POST, owner-only, sets status to resolved)
- `backend/api/urls.py` — added `items/<int:pk>/mark-resolved/` URL pattern
- `frontend/src/app/core/services/item.service.ts` — added `getMyItems()` and `markResolved(id)` methods
- `frontend/src/app/core/services/auth.service.ts` — made `clearTokens()` public for interceptor use
- `frontend/src/app/core/interceptors/auth.interceptor.ts` — added 401 handling: clears tokens and redirects to `/login`
- `frontend/src/app/pages/my-items/my-items.ts` — new `MyItemsComponent` page using `getMyItems()`
- `frontend/src/app/pages/my-items/my-items.html` — template with loading/empty/error states and item grid
- `frontend/src/app/app.routes.ts` — added `items/me` route before `items/:id`
- `frontend/src/app/pages/item-detail/item-detail.ts` — added `isNaN` guard for non-numeric `:id` params
- `frontend/src/app/pages/items/items.html` — fixed dropdown arrow padding inconsistency

## How to test
- **Mark resolved:** `curl -X POST http://127.0.0.1:8000/api/items/1/mark-resolved/ -H "Authorization: Bearer <token>"` — returns updated item with `status: "resolved"`
- **My items page:** navigate to `localhost:4200/items/me` — shows only the logged-in user's items
- **401 redirect:** clear localStorage tokens, refresh any protected page — should redirect to `/login`
- **Invalid ID guard:** navigate to `localhost:4200/items/abc` — should redirect to `/items`
- **Dropdown styling:** check filter dropdowns on `/items` page — arrows should be consistent