### PR TITLE
feat: separate register page from login component

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 
 import { LoginComponent } from './pages/login/login';
+import { RegisterComponent } from './pages/register/register';
 import { ItemsComponent } from './pages/items/items';
 import { MyItemsComponent } from './pages/my-items/my-items';
 import { ItemDetailComponent } from './pages/item-detail/item-detail';
@@ -8,8 +9,8 @@ import { ItemFormComponent } from './pages/item-form/item-form';
 import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
-  { path: 'login', component: LoginComponent, data: { mode: 'login' } },
-  { path: 'register', component: LoginComponent, data: { mode: 'register' } },
+  { path: 'login', component: LoginComponent },
+  { path: 'register', component: RegisterComponent },
   { path: 'items', component: ItemsComponent, canActivate: [authGuard] },
   { path: 'items/me', component: MyItemsComponent, canActivate: [authGuard] },
   { path: 'items/:id', component: ItemDetailComponent, canActivate: [authGuard] },

--- a/frontend/src/app/pages/login/login.ts
+++ b/frontend/src/app/pages/login/login.ts
@@ -1,12 +1,9 @@
-import { Component, inject, OnInit, OnDestroy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { Router, RouterLink } from '@angular/router';
 
 import { AuthService } from '../../core/services/auth.service';
-import { LoginRequest, RegisterRequest } from '../../models/auth.model';
-
-export type AuthMode = 'login' | 'register';
+import { LoginRequest } from '../../models/auth.model';
 
 @Component({
   selector: 'app-login',
@@ -15,54 +12,18 @@ export type AuthMode = 'login' | 'register';
   templateUrl: './login.html',
   styleUrl: './login.css',
 })
-export class LoginComponent implements OnInit, OnDestroy {
+export class LoginComponent {
   private authService = inject(AuthService);
   private router = inject(Router);
-  private route = inject(ActivatedRoute);
-  private routeDataSub?: Subscription;
-
-  mode: AuthMode = 'login';
 
   username = '';
-  email = '';
   password = '';
-  passwordConfirm = '';
   errorMessage = '';
 
   readonly logoSrc = '/kbtu-logo.png';
 
-  ngOnInit(): void {
-    this.routeDataSub = this.route.data.subscribe((data) => {
-      const m = data['mode'] as AuthMode | undefined;
-      this.mode = m === 'register' ? 'register' : 'login';
-      this.errorMessage = '';
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.routeDataSub?.unsubscribe();
-  }
-
   onSubmit(): void {
     this.errorMessage = '';
-
-    if (this.mode === 'register') {
-      const data: RegisterRequest = {
-        username: this.username,
-        email: this.email,
-        password: this.password,
-        password_confirm: this.passwordConfirm,
-      };
-      this.authService.register(data).subscribe({
-        next: () => {
-          this.router.navigate(['/login']);
-        },
-        error: (err: unknown) => {
-          this.errorMessage = this.formatRegisterError(err);
-        },
-      });
-      return;
-    }
 
     const data: LoginRequest = {
       username: this.username,
@@ -78,22 +39,5 @@ export class LoginComponent implements OnInit, OnDestroy {
         this.errorMessage = detail || 'Login failed. Please try again.';
       },
     });
-  }
-
-  private formatRegisterError(err: unknown): string {
-    const e = err as { error?: Record<string, unknown> };
-    if (e.error && typeof e.error === 'object') {
-      const messages: string[] = [];
-      for (const key of Object.keys(e.error)) {
-        const value = e.error[key];
-        if (Array.isArray(value)) {
-          messages.push(...value.map(String));
-        } else {
-          messages.push(String(value));
-        }
-      }
-      return messages.join(' ');
-    }
-    return 'Registration failed. Please try again.';
   }
 }

--- a/frontend/src/app/pages/register/register.css
+++ b/frontend/src/app/pages/register/register.css
@@ -1,0 +1,142 @@
+/* Auth page: centered panel + KBTU logo (scoped to LoginComponent) */
+
+:host {
+  --text: #111827;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --primary: #2aa8d6;
+  --primary-hover: #1e92bd;
+  --danger: #b00020;
+  display: block;
+}
+
+.auth-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--text);
+  background: #f3f4f6;
+}
+
+.auth-card {
+  width: min(460px, 100%);
+  margin: 0 auto;
+  background: #fff;
+  box-shadow: 0 25px 80px rgba(17, 24, 39, 0.12);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+/* Form panel */
+.auth-panel {
+  padding: 40px 40px 36px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: #ffffff;
+}
+
+.logo-badge {
+  align-self: flex-start;
+  padding: 12px 16px;
+  margin-bottom: 24px;
+  background: #ffffff;
+  border-radius: 14px;
+  box-shadow: 0 1px 3px rgba(17, 24, 39, 0.08);
+  border: 1px solid var(--border);
+}
+
+.logo-img {
+  display: block;
+  max-width: min(220px, 100%);
+  height: auto;
+}
+
+.auth-title {
+  margin: 0 0 20px;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.auth-form {
+  display: grid;
+  gap: 14px;
+  width: 100%;
+}
+
+.auth-field label {
+  display: block;
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0 0 6px;
+}
+
+.auth-field input {
+  width: 100%;
+  padding: 12px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  outline: none;
+  font-size: 14px;
+  background: #fff;
+}
+
+.auth-field input:focus {
+  border-color: rgba(42, 168, 214, 0.6);
+  box-shadow: 0 0 0 4px rgba(42, 168, 214, 0.15);
+}
+
+.auth-actions {
+  margin-top: 6px;
+}
+
+.auth-button {
+  appearance: none;
+  border: 0;
+  border-radius: 10px;
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  background: var(--primary);
+  width: 100%;
+}
+
+.auth-button:hover {
+  background: var(--primary-hover);
+}
+
+.auth-footer {
+  margin-top: 20px;
+  font-size: 14px;
+}
+
+.auth-footer a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.auth-footer a:hover {
+  text-decoration: underline;
+}
+
+.auth-error {
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border: 1px solid rgba(176, 0, 32, 0.25);
+  background: rgba(176, 0, 32, 0.06);
+  color: var(--danger);
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+@media (max-width: 900px) {
+  .auth-panel {
+    padding: 28px 22px 32px;
+  }
+}

--- a/frontend/src/app/pages/register/register.html
+++ b/frontend/src/app/pages/register/register.html
@@ -5,7 +5,7 @@
         <img [src]="logoSrc" alt="KBTU" class="logo-img" />
       </div>
 
-      <h1 class="auth-title">Login</h1>
+      <h1 class="auth-title">Register</h1>
 
       @if (errorMessage) {
         <div class="auth-error">{{ errorMessage }}</div>
@@ -25,24 +25,48 @@
         </div>
 
         <div class="auth-field">
+          <label for="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            [(ngModel)]="email"
+            name="email"
+            autocomplete="email"
+            required
+          />
+        </div>
+
+        <div class="auth-field">
           <label for="password">Password</label>
           <input
             id="password"
             type="password"
             [(ngModel)]="password"
             name="password"
-            autocomplete="current-password"
+            autocomplete="new-password"
+            required
+          />
+        </div>
+
+        <div class="auth-field">
+          <label for="passwordConfirm">Confirm password</label>
+          <input
+            id="passwordConfirm"
+            type="password"
+            [(ngModel)]="passwordConfirm"
+            name="passwordConfirm"
+            autocomplete="new-password"
             required
           />
         </div>
 
         <div class="auth-actions">
-          <button class="auth-button" type="submit">Login</button>
+          <button class="auth-button" type="submit">Register</button>
         </div>
       </form>
 
       <div class="auth-footer">
-        <a routerLink="/register">Sign up</a>
+        <a routerLink="/login">Sign in</a>
       </div>
     </section>
   </div>

--- a/frontend/src/app/pages/register/register.ts
+++ b/frontend/src/app/pages/register/register.ts
@@ -1,0 +1,62 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+
+import { AuthService } from '../../core/services/auth.service';
+import { RegisterRequest } from '../../models/auth.model';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [FormsModule, RouterLink],
+  templateUrl: './register.html',
+  styleUrl: './register.css',
+})
+export class RegisterComponent {
+  private authService = inject(AuthService);
+  private router = inject(Router);
+
+  username = '';
+  email = '';
+  password = '';
+  passwordConfirm = '';
+  errorMessage = '';
+
+  readonly logoSrc = '/kbtu-logo.png';
+
+  onSubmit(): void {
+    this.errorMessage = '';
+
+    const data: RegisterRequest = {
+      username: this.username,
+      email: this.email,
+      password: this.password,
+      password_confirm: this.passwordConfirm,
+    };
+    this.authService.register(data).subscribe({
+      next: () => {
+        this.router.navigate(['/login']);
+      },
+      error: (err: unknown) => {
+        this.errorMessage = this.formatRegisterError(err);
+      },
+    });
+  }
+
+  private formatRegisterError(err: unknown): string {
+    const e = err as { error?: Record<string, unknown> };
+    if (e.error && typeof e.error === 'object') {
+      const messages: string[] = [];
+      for (const key of Object.keys(e.error)) {
+        const value = e.error[key];
+        if (Array.isArray(value)) {
+          messages.push(...value.map(String));
+        } else {
+          messages.push(String(value));
+        }
+      }
+      return messages.join(' ');
+    }
+    return 'Registration failed. Please try again.';
+  }
+}


### PR DESCRIPTION
## Summary
- Extracted registration logic from `LoginComponent` into a dedicated `RegisterComponent` with its own template and styles
- Simplified `LoginComponent` to only handle login — removed mode-switching, register fields, and `OnInit`/`OnDestroy` lifecycle
- Updated route config to point `/register` at the new `RegisterComponent`

## Test plan
- [ ] Navigate to `/login` — only username/password fields shown, "Sign up" link goes to `/register`
- [ ] Navigate to `/register` — username, email, password, confirm password fields shown, "Sign in" link goes to `/login`
- [ ] Submit valid registration — redirects to `/login`
- [ ] Submit invalid registration — error message displayed
- [ ] Submit valid login — redirects to `/items`
- [ ] Submit invalid login — error message displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)