### PR TITLE
test: add Item CRUD tests and Postman collection (#16)

### DIFF
--- a/LostAndFound.postman_collection.json
+++ b/LostAndFound.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "name": "Lost & Found - Auth",
+    "name": "Lost & Found",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -9,7 +9,11 @@
     { "key": "refresh", "value": "" },
     { "key": "username", "value": "" },
     { "key": "email", "value": "" },
-    { "key": "password", "value": "Passw0rd!" }
+    { "key": "password", "value": "Passw0rd!" },
+    { "key": "itemId", "value": "" },
+    { "key": "categoryId", "value": "" },
+    { "key": "access2", "value": "" },
+    { "key": "refresh2", "value": "" }
   ],
   "item": [
     {
@@ -242,7 +246,343 @@
           }
         }
       ]
+    },
+    {
+      "name": "Items",
+      "item": [
+        {
+          "name": "Get categories",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function () { pm.response.to.have.status(200); });",
+                  "const data = pm.response.json();",
+                  "pm.test('returns array', function () { pm.expect(data).to.be.an('array'); });",
+                  "if (data.length > 0) { pm.collectionVariables.set('categoryId', data[0].id); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/categories/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "categories", ""]
+            }
+          }
+        },
+        {
+          "name": "Create item (authenticated)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function () { pm.response.to.have.status(201); });",
+                  "const data = pm.response.json();",
+                  "pm.test('has id', function () { pm.expect(data.id).to.be.a('number'); });",
+                  "pm.test('status is active', function () { pm.expect(data.status).to.eql('active'); });",
+                  "pm.collectionVariables.set('itemId', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{access}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Lost iPhone\",\n  \"description\": \"Black iPhone 15 lost near library\",\n  \"item_type\": \"lost\",\n  \"location\": \"Main Library\",\n  \"date_lost_or_found\": \"2026-04-10\",\n  \"category\": {{categoryId}}\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/items/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", ""]
+            }
+          }
+        },
+        {
+          "name": "Create item (unauthenticated -> 401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function () { pm.response.to.have.status(401); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Should fail\",\n  \"description\": \"No token\",\n  \"item_type\": \"lost\",\n  \"location\": \"Nowhere\",\n  \"date_lost_or_found\": \"2026-04-10\",\n  \"category\": {{categoryId}}\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/items/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", ""]
+            }
+          }
+        },
+        {
+          "name": "List items",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function () { pm.response.to.have.status(200); });",
+                  "pm.test('returns array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/items/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", ""]
+            }
+          }
+        },
+        {
+          "name": "List items (filter by item_type)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function () { pm.response.to.have.status(200); });",
+                  "const data = pm.response.json();",
+                  "pm.test('all items are lost', function () {",
+                  "  data.forEach(function (item) { pm.expect(item.item_type).to.eql('lost'); });",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/items/?item_type=lost",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", ""],
+              "query": [{ "key": "item_type", "value": "lost" }]
+            }
+          }
+        },
+        {
+          "name": "List items (filter by category)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/items/?category={{categoryId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", ""],
+              "query": [{ "key": "category", "value": "{{categoryId}}" }]
+            }
+          }
+        },
+        {
+          "name": "List items (search)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/items/?search=iPhone",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", ""],
+              "query": [{ "key": "search", "value": "iPhone" }]
+            }
+          }
+        },
+        {
+          "name": "Get item detail",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function () { pm.response.to.have.status(200); });",
+                  "const data = pm.response.json();",
+                  "pm.test('has expected fields', function () {",
+                  "  pm.expect(data).to.have.property('title');",
+                  "  pm.expect(data).to.have.property('category_name');",
+                  "  pm.expect(data).to.have.property('owner_username');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{access}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/items/{{itemId}}/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", "{{itemId}}", ""]
+            }
+          }
+        },
+        {
+          "name": "Update item (owner - PUT)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function () { pm.response.to.have.status(200); });",
+                  "pm.test('title updated', function () { pm.expect(pm.response.json().title).to.eql('Lost iPhone (updated)'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{access}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Lost iPhone (updated)\",\n  \"description\": \"Updated description\",\n  \"item_type\": \"lost\",\n  \"location\": \"New Library\",\n  \"date_lost_or_found\": \"2026-04-10\",\n  \"category\": {{categoryId}}\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/items/{{itemId}}/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", "{{itemId}}", ""]
+            }
+          }
+        },
+        {
+          "name": "Update item (non-owner -> 403)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const suffix = Date.now();",
+                  "const username2 = `user2_${suffix}`;",
+                  "",
+                  "pm.sendRequest({",
+                  "  url: pm.collectionVariables.get('baseUrl') + '/api/auth/register/',",
+                  "  method: 'POST',",
+                  "  header: { 'Content-Type': 'application/json' },",
+                  "  body: {",
+                  "    mode: 'raw',",
+                  "    raw: JSON.stringify({",
+                  "      username: username2,",
+                  "      email: username2 + '@example.com',",
+                  "      password: pm.collectionVariables.get('password'),",
+                  "      password_confirm: pm.collectionVariables.get('password')",
+                  "    })",
+                  "  }",
+                  "}, function (err, res) {",
+                  "  pm.collectionVariables.set('access2', res.json().access);",
+                  "  pm.collectionVariables.set('refresh2', res.json().refresh);",
+                  "});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function () { pm.response.to.have.status(403); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{access2}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Hacked title\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/items/{{itemId}}/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", "{{itemId}}", ""]
+            }
+          }
+        },
+        {
+          "name": "Delete item (unauthenticated -> 401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function () { pm.response.to.have.status(401); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{baseUrl}}/api/items/{{itemId}}/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", "{{itemId}}", ""]
+            }
+          }
+        },
+        {
+          "name": "Delete item (owner)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 No Content', function () { pm.response.to.have.status(204); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [{ "key": "Authorization", "value": "Bearer {{access}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/items/{{itemId}}/",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "items", "{{itemId}}", ""]
+            }
+          }
+        }
+      ]
     }
   ]
 }
-

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,3 +1,236 @@
-from django.test import TestCase
+from datetime import date
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from .models import Category, Item
+
+
+class CategoryTests(APITestCase):
+    def setUp(self):
+        Category.objects.get_or_create(name='Electronics', defaults={'description': 'Electronic devices'})
+        Category.objects.get_or_create(name='Books', defaults={'description': 'Textbooks and notebooks'})
+
+    def test_list_categories(self):
+        response = self.client.get('/api/categories/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(response.data), 2)
+
+    def test_list_categories_unauthenticated(self):
+        response = self.client.get('/api/categories/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class ItemCreateTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='Testpass1!')
+        self.category, _ = Category.objects.get_or_create(name='Electronics')
+        self.valid_payload = {
+            'title': 'Lost iPhone',
+            'description': 'Black iPhone 15 lost near library',
+            'item_type': 'lost',
+            'location': 'Main Library',
+            'date_lost_or_found': '2026-04-10',
+            'category': self.category.pk,
+        }
+
+    def test_create_item_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post('/api/items/', self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['title'], 'Lost iPhone')
+        self.assertEqual(response.data['owner'], self.user.pk)
+        self.assertEqual(response.data['status'], 'active')
+
+    def test_create_item_unauthenticated(self):
+        response = self.client.post('/api/items/', self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create_item_missing_fields(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post('/api/items/', {'title': 'Incomplete'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class ItemListTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='Testpass1!')
+        self.cat1, _ = Category.objects.get_or_create(name='Electronics')
+        self.cat2, _ = Category.objects.get_or_create(name='Books')
+        Item.objects.create(
+            title='Lost iPhone',
+            description='Black iPhone',
+            item_type='lost',
+            status='active',
+            location='Library',
+            date_lost_or_found=date(2026, 4, 10),
+            owner=self.user,
+            category=self.cat1,
+        )
+        Item.objects.create(
+            title='Found Textbook',
+            description='Calculus textbook',
+            item_type='found',
+            status='resolved',
+            location='Cafeteria',
+            date_lost_or_found=date(2026, 4, 11),
+            owner=self.user,
+            category=self.cat2,
+        )
+
+    def test_list_items(self):
+        response = self.client.get('/api/items/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_filter_by_item_type(self):
+        response = self.client.get('/api/items/', {'item_type': 'lost'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['item_type'], 'lost')
+
+    def test_filter_by_category(self):
+        response = self.client.get('/api/items/', {'category': self.cat2.pk})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Found Textbook')
+
+    def test_filter_by_status(self):
+        response = self.client.get('/api/items/', {'status': 'active'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Lost iPhone')
+
+    def test_search_by_title(self):
+        response = self.client.get('/api/items/', {'search': 'iPhone'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_search_by_description(self):
+        response = self.client.get('/api/items/', {'search': 'Calculus'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_filter_no_results(self):
+        response = self.client.get('/api/items/', {'item_type': 'found', 'status': 'active'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
+
+class ItemDetailTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='Testpass1!')
+        self.category, _ = Category.objects.get_or_create(name='Electronics')
+        self.item = Item.objects.create(
+            title='Lost iPhone',
+            description='Black iPhone',
+            item_type='lost',
+            location='Library',
+            date_lost_or_found=date(2026, 4, 10),
+            owner=self.user,
+            category=self.category,
+        )
+
+    def test_get_item_detail(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f'/api/items/{self.item.pk}/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], 'Lost iPhone')
+        self.assertEqual(response.data['category_name'], 'Electronics')
+        self.assertEqual(response.data['owner_username'], 'owner')
+
+    def test_get_item_not_found(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get('/api/items/9999/')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class ItemUpdateTests(APITestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username='owner', password='Testpass1!')
+        self.other_user = User.objects.create_user(username='other', password='Testpass1!')
+        self.category, _ = Category.objects.get_or_create(name='Electronics')
+        self.item = Item.objects.create(
+            title='Lost iPhone',
+            description='Black iPhone',
+            item_type='lost',
+            location='Library',
+            date_lost_or_found=date(2026, 4, 10),
+            owner=self.owner,
+            category=self.category,
+        )
+
+    def test_update_item_owner_put(self):
+        self.client.force_authenticate(user=self.owner)
+        payload = {
+            'title': 'Lost iPhone (updated)',
+            'description': 'Updated description',
+            'item_type': 'lost',
+            'location': 'New Library',
+            'date_lost_or_found': '2026-04-10',
+            'category': self.category.pk,
+        }
+        response = self.client.put(f'/api/items/{self.item.pk}/', payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], 'Lost iPhone (updated)')
+
+    def test_update_item_owner_patch(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            f'/api/items/{self.item.pk}/',
+            {'title': 'Patched title'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], 'Patched title')
+
+    def test_update_item_non_owner(self):
+        self.client.force_authenticate(user=self.other_user)
+        response = self.client.patch(
+            f'/api/items/{self.item.pk}/',
+            {'title': 'Hacked'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_item_unauthenticated(self):
+        response = self.client.patch(
+            f'/api/items/{self.item.pk}/',
+            {'title': 'Hacked'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class ItemDeleteTests(APITestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username='owner', password='Testpass1!')
+        self.other_user = User.objects.create_user(username='other', password='Testpass1!')
+        self.category, _ = Category.objects.get_or_create(name='Electronics')
+        self.item = Item.objects.create(
+            title='Lost iPhone',
+            description='Black iPhone',
+            item_type='lost',
+            location='Library',
+            date_lost_or_found=date(2026, 4, 10),
+            owner=self.owner,
+            category=self.category,
+        )
+
+    def test_delete_item_owner(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(f'/api/items/{self.item.pk}/')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Item.objects.filter(pk=self.item.pk).exists())
+
+    def test_delete_item_non_owner(self):
+        self.client.force_authenticate(user=self.other_user)
+        response = self.client.delete(f'/api/items/{self.item.pk}/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(Item.objects.filter(pk=self.item.pk).exists())
+
+    def test_delete_item_unauthenticated(self):
+        response = self.client.delete(f'/api/items/{self.item.pk}/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertTrue(Item.objects.filter(pk=self.item.pk).exists())


### PR DESCRIPTION
## Issue
Closes #16

## Changes
- `backend/api/tests.py` — Added 21 tests across 6 test classes covering:
  - Category listing (authenticated and unauthenticated)
  - Item creation (authenticated, unauthenticated, missing fields)
  - Item listing with filters (item_type, category, status, search, combined)
  - Item detail retrieval and 404 handling
  - Item update (owner PUT/PATCH, non-owner 403, unauthenticated 401)
  - Item delete (owner 204, non-owner 403, unauthenticated 401)
- `LostAndFound.postman_collection.json` — Added "Items" folder with 12 requests:
  - Get categories, Create item (auth + unauth), List items (no filter + 3 filter variants), Get item detail, Update item (owner + non-owner), Delete item (owner + unauth)

## How to test
1. Run Django tests:
   ```bash
   cd backend && source venv/bin/activate && python manage.py test api -v2
   ```
   All 21 tests should pass.

2. Postman collection:
   - Import `LostAndFound.postman_collection.json` into Postman
   - Start backend: `cd backend && python manage.py runserver`
   - Run "Auth" folder first (Register + Login to get tokens)
   - Run "Items" folder sequentially — all test assertions should pass